### PR TITLE
use CLI flags for LightGBM GPU install

### DIFF
--- a/Rdatascience/image_rdsc_gpu/Dockerfile
+++ b/Rdatascience/image_rdsc_gpu/Dockerfile
@@ -98,8 +98,7 @@ RUN echo "R_DATATABLE_NUM_PROCS_PERCENT=100" >> /etc/R/Renviron
 # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html
 RUN git clone --recursive https://github.com/microsoft/LightGBM
 RUN cd LightGBM && \
-    sed -i -e 's/use_gpu <- FALSE/use_gpu <- TRUE/g' R-package/src/install.libs.R && \
-    Rscript build_r.R
+    Rscript build_r.R --use-gpu
 
 # install xgboost GPU R package
 # xgboost branch

--- a/Rdatascience/image_rdsc_gpu_base/Dockerfile
+++ b/Rdatascience/image_rdsc_gpu_base/Dockerfile
@@ -228,8 +228,7 @@ RUN mkdir -p /etc/OpenCL/vendors && \
 # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html
 RUN git clone --recursive https://github.com/microsoft/LightGBM
 RUN cd LightGBM && \
-    sed -i -e 's/use_gpu <- FALSE/use_gpu <- TRUE/g' R-package/src/install.libs.R && \
-    Rscript build_r.R
+    Rscript build_r.R --use-gpu
 
 # install xgboost GPU R package
 # installation will work only with g++/gcc version <= 8


### PR DESCRIPTION
`{lightgbm}`'s CMake-based build (the non-CRAN one) no longer requires manually changing variables in `R-package/install.libs.R`. As of https://github.com/microsoft/LightGBM/pull/3574, you can pass flags like `Rscript build_r.R --use-gpu`.

This PR proposes changing the dockerfiles in this project to use that strategy, since it's less likely to be broken by future changes to `{lightgbm}`.